### PR TITLE
feat: wire image delete callback and fix edit history + caption deletion

### DIFF
--- a/app/src/main/java/off/kys/backtalk/presentation/event/MessagesUiEvent.kt
+++ b/app/src/main/java/off/kys/backtalk/presentation/event/MessagesUiEvent.kt
@@ -161,4 +161,12 @@ sealed interface MessagesUiEvent {
      * UI event to notify that the scroll to a search result has been consumed.
      */
     data object ConsumedScrollToSearch : MessagesUiEvent
+
+    /**
+     * UI event to remove a single image from a message.
+     *
+     * @param messageId The ID of the message containing the image.
+     * @param imagePath The file path of the image to remove.
+     */
+    data class RemoveImageFromMessage(val messageId: MessageId, val imagePath: String) : MessagesUiEvent
 }

--- a/app/src/main/java/off/kys/backtalk/presentation/screen/messages/MessagesScreen.kt
+++ b/app/src/main/java/off/kys/backtalk/presentation/screen/messages/MessagesScreen.kt
@@ -204,7 +204,9 @@ fun MessagesScreenContent(
         },
         bottomBar = {
             InputBar(
-                messageInput = state.editingMessage?.let { it.editedText ?: it.text }.orEmpty(),
+                messageInput = state.editingMessage?.editedText.orEmpty().ifEmpty {
+                    state.editingMessage?.text.orEmpty()
+                },
                 replyingTo = state.replyingTo,
                 editingMessage = state.editingMessage,
                 onCancelReply = { onEvent(MessagesUiEvent.ReplyTo(null)) },
@@ -275,6 +277,9 @@ fun MessagesScreenContent(
             onScrollToMessage = { id ->
                 scrollToAndBlink(id)
                 onEvent(MessagesUiEvent.ScrollToMessage(id))
+            },
+            onImageDelete = { messageId, imagePath ->
+                onEvent(MessagesUiEvent.RemoveImageFromMessage(messageId, imagePath))
             }
         )
     }

--- a/app/src/main/java/off/kys/backtalk/presentation/screen/messages/components/MessageBubble.kt
+++ b/app/src/main/java/off/kys/backtalk/presentation/screen/messages/components/MessageBubble.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -27,8 +28,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -82,7 +85,8 @@ fun MessageBubble(
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     highlightQuery: String? = null,
-    onTagClick: (String) -> Unit = {}
+    onTagClick: (String) -> Unit = {},
+    onImageDelete: ((String) -> Unit)? = null
 ) {
     var showExtraInfo by remember { mutableStateOf(false) }
     val haptic = LocalHapticFeedback.current
@@ -150,7 +154,8 @@ fun MessageBubble(
                 onReplyClick = onReplyPreviewClick,
                 showOriginal = showExtraInfo,
                 highlightQuery = highlightQuery,
-                onTagClick = onTagClick
+                onTagClick = onTagClick,
+                onImageDelete = onImageDelete
             )
         }
 
@@ -233,7 +238,8 @@ private fun MessageContent(
     onReplyClick: () -> Unit,
     showOriginal: Boolean,
     highlightQuery: String? = null,
-    onTagClick: (String) -> Unit = {}
+    onTagClick: (String) -> Unit = {},
+    onImageDelete: ((String) -> Unit)? = null
 ) {
     val navigator = LocalNavigator.current
     val contentColor = contentColorFor(MaterialTheme.colorScheme.primary)
@@ -270,7 +276,11 @@ private fun MessageContent(
     }
 
     if (images.isNotEmpty()) {
-        StaggeredImageGrid(images) { imagePath -> navigator?.push(ImagePreviewScreen(imagePath)) }
+        StaggeredImageGrid(
+            images = images,
+            onImageClick = { imagePath -> navigator?.push(ImagePreviewScreen(imagePath)) },
+            onImageDelete = onImageDelete
+        )
         val messageText = message.editedText ?: message.text
         if (messageText.isNotEmpty() || message.voicePath != null) {
             Spacer(modifier = Modifier.height(4.dp))
@@ -323,7 +333,8 @@ private fun MessageContent(
 fun StaggeredImageGrid(
     images: List<String>,
     modifier: Modifier = Modifier,
-    onImageClick: (String) -> Unit
+    onImageClick: (String) -> Unit,
+    onImageDelete: ((String) -> Unit)? = null
 ) {
     if (images.isEmpty()) return
 
@@ -335,17 +346,16 @@ fun StaggeredImageGrid(
 
     when (images.size) {
         1 -> {
-            val path = images[0]
-            AsyncImage(
-                model = File(path),
-                contentDescription = null,
+            GridImage(
+                path = images[0],
                 modifier = Modifier
                     .clip(MaterialTheme.shapes.large)
                     .sizeIn(
                         minWidth = 140.dp, maxWidth = gridWidth,
                         minHeight = 140.dp, maxHeight = 360.dp
-                    )
-                    .clickable { onImageClick(path) },
+                    ),
+                onClick = onImageClick,
+                onDelete = onImageDelete,
                 contentScale = ContentScale.Fit
             )
         }
@@ -361,7 +371,8 @@ fun StaggeredImageGrid(
                         modifier = Modifier
                             .weight(1f)
                             .aspectRatio(0.75f),
-                        onClick = onImageClick
+                        onClick = onImageClick,
+                        onDelete = onImageDelete
                     )
                 }
             }
@@ -377,7 +388,8 @@ fun StaggeredImageGrid(
                     modifier = Modifier
                         .weight(1f)
                         .aspectRatio(0.75f),
-                    onClick = onImageClick
+                    onClick = onImageClick,
+                    onDelete = onImageDelete
                 )
                 Column(
                     modifier = Modifier.weight(1f),
@@ -389,7 +401,8 @@ fun StaggeredImageGrid(
                             .fillMaxWidth()
                             .weight(1f)
                             .aspectRatio(1.5f),
-                        onClick = onImageClick
+                        onClick = onImageClick,
+                        onDelete = onImageDelete
                     )
                     GridImage(
                         path = images[2],
@@ -397,7 +410,8 @@ fun StaggeredImageGrid(
                             .fillMaxWidth()
                             .weight(1f)
                             .aspectRatio(1.5f),
-                        onClick = onImageClick
+                        onClick = onImageClick,
+                        onDelete = onImageDelete
                     )
                 }
             }
@@ -417,14 +431,16 @@ fun StaggeredImageGrid(
                         modifier = Modifier
                             .fillMaxWidth()
                             .aspectRatio(1f),
-                        onClick = onImageClick
+                        onClick = onImageClick,
+                        onDelete = onImageDelete
                     )
                     GridImage(
                         path = images[2],
                         modifier = Modifier
                             .fillMaxWidth()
                             .aspectRatio(1.5f),
-                        onClick = onImageClick
+                        onClick = onImageClick,
+                        onDelete = onImageDelete
                     )
                 }
                 Column(
@@ -436,14 +452,16 @@ fun StaggeredImageGrid(
                         modifier = Modifier
                             .fillMaxWidth()
                             .aspectRatio(1.5f),
-                        onClick = onImageClick
+                        onClick = onImageClick,
+                        onDelete = onImageDelete
                     )
                     GridImage(
                         path = images[3],
                         modifier = Modifier
                             .fillMaxSize()
                             .aspectRatio(1f),
-                        onClick = onImageClick
+                        onClick = onImageClick,
+                        onDelete = onImageDelete
                     )
                 }
             }
@@ -455,14 +473,48 @@ fun StaggeredImageGrid(
 private fun GridImage(
     path: String,
     modifier: Modifier = Modifier,
-    onClick: (String) -> Unit
+    onClick: (String) -> Unit,
+    onDelete: ((String) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Crop
 ) {
-    AsyncImage(
-        model = File(path),
-        contentDescription = null,
-        modifier = modifier.clickable { onClick(path) },
-        contentScale = ContentScale.Crop
-    )
+    val haptic = LocalHapticFeedback.current
+    val preferences = koinInject<BacktalkPreferences>()
+
+    Box(modifier = modifier) {
+        AsyncImage(
+            model = File(path),
+            contentDescription = null,
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable { onClick(path) },
+            contentScale = contentScale
+        )
+        if (onDelete != null) {
+            IconButton(
+                onClick = {
+                    if (preferences.hapticFeedbackEnabled) {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    }
+                    onDelete(path)
+                },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(4.dp)
+                    .size(28.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.85f),
+                        shape = CircleShape
+                    )
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.round_delete_24),
+                    contentDescription = stringResource(R.string.common_delete),
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier.size(14.dp)
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/off/kys/backtalk/presentation/screen/messages/components/MessagesContent.kt
+++ b/app/src/main/java/off/kys/backtalk/presentation/screen/messages/components/MessagesContent.kt
@@ -47,7 +47,8 @@ fun MessagesContent(
     onNavigatePinned: () -> Unit,
     onTogglePinnedDialog: (Boolean) -> Unit,
     onTogglePin: (MessageEntity, Boolean) -> Unit,
-    onScrollToMessage: (MessageId) -> Unit
+    onScrollToMessage: (MessageId) -> Unit,
+    onImageDelete: ((MessageId, String) -> Unit)? = null,
 ) {
     val context = LocalContext.current
 
@@ -63,6 +64,7 @@ fun MessagesContent(
             onTagClick = onTagClick,
             blinkMessageId = state.blinkMessageId,
             onScrollToMessage = onScrollToMessage,
+            onImageDelete = onImageDelete,
             contentPadding = if (state.pinnedMessages.isNotEmpty()) PaddingValues(top = 48.dp) else PaddingValues(
                 0.dp
             )

--- a/app/src/main/java/off/kys/backtalk/presentation/screen/messages/components/MessagesList.kt
+++ b/app/src/main/java/off/kys/backtalk/presentation/screen/messages/components/MessagesList.kt
@@ -31,6 +31,7 @@ fun MessagesList(
     onTagClick: (String) -> Unit = {},
     blinkMessageId: MessageId? = null,
     onScrollToMessage: (MessageId) -> Unit = {},
+    onImageDelete: ((MessageId, String) -> Unit)? = null,
 ) {
     val selectionMode = selectedMessageIds.isNotEmpty()
 
@@ -75,8 +76,8 @@ fun MessagesList(
 
             val oneHourInMillis = 3600000L
             val canEdit = current.editedAt == null &&
-                    (System.currentTimeMillis() - current.timestamp) < oneHourInMillis && 
-                    current.voicePath == null
+            (System.currentTimeMillis() - current.timestamp) < oneHourInMillis &&
+            current.voicePath == null
 
             Column(
                 modifier = Modifier.animateItem(),
@@ -124,7 +125,8 @@ fun MessagesList(
                             onToggleSelect(current.id)
                         },
                         highlightQuery = searchQuery,
-                        onTagClick = onTagClick
+                        onTagClick = onTagClick,
+                        onImageDelete = onImageDelete?.let { cb -> { path -> cb(current.id, path) } }
                     )
                 }
             }

--- a/app/src/main/java/off/kys/backtalk/presentation/viewmodel/MessagesViewModel.kt
+++ b/app/src/main/java/off/kys/backtalk/presentation/viewmodel/MessagesViewModel.kt
@@ -133,6 +133,7 @@ class MessagesViewModel(
             MessagesUiEvent.ConsumedScrollToSearch -> {
                 _uiState.value = _uiState.value.copy(shouldScrollToSearch = false)
             }
+            is MessagesUiEvent.RemoveImageFromMessage -> removeImageFromMessage(event.messageId, event.imagePath)
         }
     }
 
@@ -275,9 +276,13 @@ class MessagesViewModel(
 
         if (editingMessage != null) {
             viewModelScope.launch {
+                // editedText stores the previous visible text (shown strikethrough in UI).
+                // The previous visible text is editedText ?: text (same logic as UI rendering).
+                val previousVisibleText = editingMessage.editedText ?: editingMessage.text
                 useCases.insertMessage(
                     editingMessage.copy(
                         editedText = text,
+                        text = previousVisibleText,
                         editedAt = System.currentTimeMillis()
                     )
                 )
@@ -299,6 +304,43 @@ class MessagesViewModel(
             _uiState.value = _uiState.value.copy(shouldScrollToBottom = true)
         }
         updateReply(null)
+    }
+
+    private fun removeImageFromMessage(messageId: MessageId, imagePath: String) {
+        viewModelScope.launch {
+            val message = useCases.getMessageById(messageId) ?: return@launch
+
+            val newMediaPath = if (message.mediaPath == imagePath) null else message.mediaPath
+            val newMediaPaths = message.mediaPaths
+                ?.filter { it != imagePath }
+                ?.ifEmpty { null }
+
+            val hasNoMediaLeft = newMediaPath == null && newMediaPaths.isNullOrEmpty()
+            // If all media is gone and there's no voice, delete the whole message.
+            // Text in a media message is a caption — it has no meaning without the media.
+            val hasNoContent = hasNoMediaLeft && message.voicePath == null
+
+            if (hasNoContent) {
+                // Delegate to existing use case — it handles DB delete + disk cleanup
+                useCases.deleteMessageById(messageId)
+            } else {
+                useCases.insertMessage(
+                    message.copy(
+                        mediaPath = newMediaPath,
+                        mediaPaths = newMediaPaths
+                    )
+                )
+                // Delete file from disk only if no other message still references this path
+                val allMessages = _uiState.value.messages
+                val isStillReferenced = allMessages.any { m ->
+                    m.id != messageId &&
+                            (m.mediaPath == imagePath || m.mediaPaths?.contains(imagePath) == true)
+                }
+                if (!isStillReferenced) {
+                    File(imagePath).let { if (it.exists()) it.delete() }
+                }
+            }
+        }
     }
 
     private fun sendVoiceMessage(path: String, duration: Long, waveform: List<Float>) {


### PR DESCRIPTION
feat: wire image delete callback and fix edit history + caption deletion Wire onImageDelete through MessagesList → MessagesContent → MessagesScreen:
- MessagesContent: add optional onImageDelete: ((MessageId, String) -> Unit)? param
- MessagesList: add same param, convert (MessageId, String) to (String) for MessageBubble
- MessagesScreen: wire to onEvent(RemoveImageFromMessage(messageId, imagePath))

Fix edit history showing wrong previous value:
- Previously: text = original (never changed), editedText = latest edit → strikethrough always showed the original, not the previous edit
- Now: editedText = latest text, text = previous visible text (rotated on each edit) → strikethrough now correctly shows the last value before current edit
- InputBar pre-fill updated to read editedText (current value) correctly

Fix caption retained after last image deleted:
- Previously: hasNoContent checked message.text.isBlank(), so caption kept the message alive as a plain text bubble after all images were removed
- Now: if all media is gone and no voice, delete the whole message regardless of text, since text in a media message is a caption without the image